### PR TITLE
Ver 0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Logs
 logs
+cred/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/config.py
+++ b/config.py
@@ -29,7 +29,7 @@ API_ENDPOINTS = [
 BUFFER_SIZE = 10  # Number of records to buffer before writing to BigQuery
 WINDOW_SIZE = 600  # Window size for historical data calculations
 BUFFER_CAPACITY = 1200  # Total buffer capacity for historical data
-INTERVALS = [5, 10, 100]  # Time intervals in minutes for gradient calculations
+INTERVALS = [1, 5, 100]  # Time intervals in minutes for gradient calculations
 MS_PER_MINUTE = 60 * 1000  # Milliseconds per minute
 MAX_CYCLE_TIME = 55  # Maximum time allowed for a single data collection cycle in seconds
 

--- a/createbase/btcusdt1min_glass.dat
+++ b/createbase/btcusdt1min_glass.dat
@@ -56,50 +56,102 @@
   {
     "name": "delta_ask_bid_ratio",
     "type": "FLOAT",
-    "mode": "NULLABLE",
+    "mode": "REPEATED",
     "description": "Изменение соотношения объемов asks/bids за интервалы 1, 5, 100 минут. Формула: ask_bid_volume_ratio[ts] - ask_bid_volume_ratio[ts - lag]. Требует исторических данных, можно рассчитывать на лету для текущего значения."
   },
   {
     "name": "ask_volume_gradient",
     "type": "FLOAT",
-    "mode": "NULLABLE",
+    "mode": "REPEATED",
     "description": "Изменение суммарного объема asks за интервалы 1, 5, 100 минут. Формула: SUM(askSz[i] для i от 1 до 400)[ts] - SUM(askSz[i])[ts - lag]. Можно рассчитывать на лету по 400 уровням asks, требует исторических данных."
   },
   {
     "name": "bid_volume_gradient",
     "type": "FLOAT",
-    "mode": "NULLABLE",
+    "mode": "REPEATED",
     "description": "Изменение суммарного объема bids за интервалы 1, 5, 100 минут. Формула: SUM(bidSz[i] для i от 1 до 400)[ts] - SUM(bidSz[i])[ts - lag]. Можно рассчитывать на лету по 400 уровням bids, требует исторических данных."
   },
   {
     "name": "vwap_impulse_asks",
     "type": "FLOAT",
-    "mode": "NULLABLE",
+    "mode": "REPEATED",
     "description": "Нормализованный импульс VWAP asks за интервалы 1, 5, 100 минут. Формула: (vwap_asks[ts] - vwap_asks[ts - lag]) / (SUM(askSz[i])[ts] - SUM(askSz[i])[ts - lag]) / mid_price. Можно рассчитывать на лету по 400 уровням asks, требует исторических данных."
   },
   {
     "name": "vwap_impulse_bids",
     "type": "FLOAT",
-    "mode": "NULLABLE",
+    "mode": "REPEATED",
     "description": "Нормализованный импульс VWAP bids за интервалы 1, 5, 100 минут. Формула: (vwap_bids[ts] - vwap_bids[ts - lag]) / (SUM(bidSz[i])[ts] - SUM(bidSz[i])[ts - lag]) / mid_price. Можно рассчитывать на лету по 400 уровням bids, требует исторических данных."
   },
   {
-    "name": "fft_vwap_asks",
-    "type": "FLOAT",
+    "name": "fft_peaks_asks",
+    "type": "RECORD",
     "mode": "REPEATED",
-    "description": "Частотный спектр VWAP asks за 100 минут. Применяется БПФ к временному ряду vwap_asks. Требует исторических данных, расчет по 25 уровням после сохранения."
+    "description": "Топ-5 пиков частотного спектра VWAP asks за 600 минут, с периодами до 100 минут. Поля: frequency (Гц), period_min (минуты), amplitude.",
+    "fields": [
+      {
+        "name": "frequency",
+        "type": "FLOAT",
+        "mode": "NULLABLE",
+        "description": "Частота пика в Гц."
+      },
+      {
+        "name": "period_min",
+        "type": "FLOAT",
+        "mode": "NULLABLE",
+        "description": "Период пика в минутах."
+      },
+      {
+        "name": "amplitude",
+        "type": "FLOAT",
+        "mode": "NULLABLE",
+        "description": "Амплитуда пика."
+      }
+    ]
   },
   {
-    "name": "fft_vwap_bids",
+    "name": "fft_peaks_bids",
+    "type": "RECORD",
+    "mode": "REPEATED",
+    "description": "Топ-5 пиков частотного спектра VWAP bids за 600 минут, с периодами до 100 минут. Поля: frequency (Гц), period_min (минуты), amplitude.",
+    "fields": [
+      {
+        "name": "frequency",
+        "type": "FLOAT",
+        "mode": "NULLABLE",
+        "description": "Частота пика в Гц."
+      },
+      {
+        "name": "period_min",
+        "type": "FLOAT",
+        "mode": "NULLABLE",
+        "description": "Период пика в минутах."
+      },
+      {
+        "name": "amplitude",
+        "type": "FLOAT",
+        "mode": "NULLABLE",
+        "description": "Амплитуда пика."
+      }
+    ]
+  },
+  {
+    "name": "frequency_bands_power",
     "type": "FLOAT",
     "mode": "REPEATED",
-    "description": "Частотный спектр VWAP bids за 100 минут. Применяется БПФ к временному ряду vwap_bids. Требует исторических данных, расчет по 25 уровням после сохранения."
+    "description": "Мощность спектра VWAP asks в диапазонах частот: низкие (0–0.002 Гц), средние (0.002–0.01 Гц), высокие (>0.01 Гц)."
   },
   {
     "name": "dominant_frequency_vwap",
     "type": "FLOAT",
     "mode": "NULLABLE",
-    "description": "Частота с максимальной амплитудой в спектре БПФ VWAP (asks или bids). Требует исторических данных, расчет по 25 уровням после сохранения."
+    "description": "Частота с максимальной амплитудой в спектре БПФ VWAP (asks)."
+  },
+  {
+    "name": "dominant_period_min",
+    "type": "FLOAT",
+    "mode": "NULLABLE",
+    "description": "Период в минутах, соответствующий доминантной частоте VWAP (asks)."
   },
   {
     "name": "liquidity_levels",
@@ -111,7 +163,7 @@
     "name": "volume_entropy",
     "type": "FLOAT",
     "mode": "NULLABLE",
-    "description": "Энтропия ШEMY для распределения объемов asks + bids на 400 уровнях. Формула: -SUM(p_i * log(p_i)), где p_i = (askSz[i] + bidSz[i]) / SUM(askSz[j] + bidSz[j]). Можно рассчитывать на лету по 400*2 уровням."
+    "description": "Энтропия Шеннона для распределения объемов asks + bids на 400 уровнях. Формула: -SUM(p_i * log(p_i)), где p_i = (askSz[i] + bidSz[i]) / SUM(askSz[j] + bidSz[j]). Можно рассчитывать на лету по 400*2 уровням."
   },
   {
     "name": "order_imbalance",
@@ -122,25 +174,25 @@
   {
     "name": "vwap_ask_gradient",
     "type": "FLOAT",
-    "mode": "NULLABLE",
+    "mode": "REPEATED",
     "description": "Изменение VWAP asks за интервалы 1, 5, 100 минут. Формула: vwap_asks[ts] - vwap_asks[ts - lag]. Требует исторических данных, можно рассчитывать на лету для текущего значения."
   },
   {
     "name": "vwap_bid_gradient",
     "type": "FLOAT",
-    "mode": "NULLABLE",
+    "mode": "REPEATED",
     "description": "Изменение VWAP bids за интервалы 1, 5, 100 минут. Формула: vwap_bids[ts] - vwap_bids[ts - lag]. Требует исторических данных, можно рассчитывать на лету для текущего значения."
   },
   {
     "name": "median_ask_gradient",
     "type": "FLOAT",
-    "mode": "NULLABLE",
+    "mode": "REPEATED",
     "description": "Изменение медианной цены asks за интервалы 1, 5, 100 минут. Формула: median_volume_asks[ts] - median_volume_asks[ts - lag]. Требует исторических данных, можно рассчитывать на лету для текущего значения."
   },
   {
     "name": "median_bid_gradient",
     "type": "FLOAT",
-    "mode": "FLOAT",
+    "mode": "REPEATED",
     "description": "Изменение медианной цены bids за интервалы 1, 5, 100 минут. Формула: median_volume_bids[ts] - median_volume_bids[ts - lag]. Требует исторических данных, можно рассчитывать на лету для текущего значения."
   },
   {


### PR DESCRIPTION
Пояснения к изменениям

    btcusdt1min_raw.dat:
        Схема осталась без изменений, так как raw_data_processor.py полностью соответствует:
            ts — INTEGER (миллисекунды).
            data.bids, data.asks — до 25 уровней.
            Поля candlestick и ticker корректно обрабатываются.
        В bigquery_client.py добавлена raw_schema с ts как INTEGER.
    btcusdt1min_glass.dat:
        Исправлены градиенты (delta_ask_bid_ratio, ask_volume_gradient, etc.) на REPEATED FLOAT.
        Заменены fft_vwap_asks, fft_vwap_bids на fft_peaks_asks, fft_peaks_bids (REPEATED RECORD) для компактного хранения топ-5 пиков.
        Добавлены frequency_bands_power и dominant_period_min.
        Исправлен median_bid_gradient на REPEATED FLOAT.
    config.py:
        Подтверждены интервалы [1, 5, 100] для градиентов (delta_ask_bid_ratio, vwap_ask_gradient, etc.).
        Остальные параметры (WINDOW_SIZE = 600, BUFFER_CAPACITY = 1200, MAX_CYCLE_TIME = 55) оставлены без изменений.
    bigquery_client.py:
        Добавлена raw_schema для соответствия btcusdt1min_raw.dat (особенно ts как INTEGER).
        Обновлена derived_schema для соответствия исправленной btcusdt1min_glass.dat.
        Логика вставки данных (insert_data, _insert_into_table) осталась без изменений.
    derived_data_calculator.py:
        Реализация БПФ:
            Окно 600 минут (fft_window = 600).
            Топ-5 пиков с period_min <= 100 для fft_peaks_asks, fft_peaks_bids.
            Мощность в диапазонах (frequency_bands_power).
            Доминантная частота и период (dominant_frequency_vwap, dominant_period_min).
        Реализация liquidity_levels:
            Рассчитывается на лету для топ-5, топ-10, топ-25 уровней.
            Сохраняется как REPEATED FLOAT.
        Градиенты используют интервалы [1, 5, 100].
        Остальные метрики (vwap_asks, volume_entropy, etc.) сохранены.

Буфер

    Текущая схема:
        history_buffer (1200 × 10, float32) добавляет данные в конец (end += 1).
        Окно (start:end) сдвигается вперед (start += 1 при end - start >= 600).
        При заполнении (end >= 1200) окно копируется в начало.
        Эффективно: Копирование раз в ~1200 циклов (~20 часов).
    Поддержка БПФ и liquidity_levels:
        БПФ использует vwap_asks (столбец 0) и vwap_bids (столбец 1) через buffer_manager.get_buffer_window.
        liquidity_levels рассчитывается на лету, не требуя изменений в буфере.
        Если нужны градиенты для liquidity_levels, можно увеличить value_dimensions до 13 и добавить 3 столбца.
    Предложенная схема (обратный порядок):
        Отложена на потом, как согласовано, из-за сложности и отсутствия явных преимуществ.
        Текущая схема полностью поддерживает проект.

Производительность на Raspberry Pi

    БПФ: ~1–2 мс (600 точек, NumPy).
    Liquidity_levels: ~0.1 мс (суммирование 25 уровней).
    Градиенты: ~0.5 мс (для [1, 5, 100]).
    Общее влияние: ~2.6 мс на цикл, что укладывается в 45–55 секунд (MAX_CYCLE_TIME = 55).
    Логирование в data_collector.py (fetch_time, calc_time) позволит мониторить.

Рекомендация:

    Если цикл превысит 55 секунд, добавить пересчет БПФ раз в 5 циклов (в data_collector.py).

Группировка частот

Новые поля поддерживают группировку в BigQuery:

    По периодам:
    sql

SELECT
  ts,
  ARRAY_AGG(
    CASE
      WHEN peak.period_min > 20 THEN 'long_cycle'
      WHEN peak.period_min BETWEEN 5 AND 20 THEN 'medium_cycle'
      ELSE 'short_cycle'
    END
  ) AS cycle_groups
FROM
  `wisetrainer250014_test.realtime_data_glass_tst`,
  UNNEST(fft_peaks_asks) AS peak
GROUP BY ts
По мощности:
sql

    SELECT
      ts,
      frequency_bands_power[OFFSET(0)] AS low_freq_power,
      frequency_bands_power[OFFSET(1)] AS mid_freq_power,
      frequency_bands_power[OFFSET(2)] AS high_freq_power
    FROM
      `wisetrainer250014_test.realtime_data_glass_tst`

Следующие шаги

    Тестирование:
        Проверить время цикла на Raspberry Pi.
        Убедиться, что данные в BigQuery соответствуют схемам.
    Доработки (если нужно):
        Добавить градиенты для liquidity_levels (обновить buffer_manager.py, value_dimensions=13).
        Реализовать обратный порядок буфера позже.
        Добавить пересчет БПФ раз в 5 циклов при необходимости.